### PR TITLE
Feature: add optional i2c bus parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The arguments, are:
     * shunt_ohms: The value of the shunt resistor in Ohms (mandatory).
     * max_expected_amps: The maximum expected current in Amps (mandatory). **Device only supports up to 3.2A.**
     * address: The I2C address of the INA219, defaults to **0x40** (optional).
+    * i2c_bus: The full path of the I2C bus device wherein the INA219 address is located, defaults to **/dev/i2c-1** (optional).
 * `configure()` configures and calibrates how the INA219 will take measurements.
 The arguments, which are all mandatory, are:
     * voltage_range: The full scale voltage range, this is either 16V or 32V, 

--- a/src/ina219.cc
+++ b/src/ina219.cc
@@ -84,13 +84,13 @@ INA219::configure(int voltage_range, int gain, int bus_adc, int shunt_adc)
 	_voltage_range = voltage_range;
 	_gain = gain;
 
-	calibrate(__BUS_RANGE[voltage_range], __GAIN_VOLTS[gain], _max_expected_amps);
+	calibrate(__GAIN_VOLTS[gain], _max_expected_amps);
 	uint16_t calibration = (voltage_range << __BRNG | _gain << __PG0 | bus_adc << __BADC1 | shunt_adc << __SADC1 | __CONT_SH_BUS);
 	write_register(__REG_CONFIG, calibration);
 }
 
 void
-INA219::calibrate(int bus_volts_max, float shunt_volts_max, float max_expected_amps)
+INA219::calibrate(float shunt_volts_max, float max_expected_amps)
 {
 	float max_possible_amps = shunt_volts_max / _shunt_ohms;
 	_current_lsb = determine_current_lsb(max_expected_amps, max_possible_amps);

--- a/src/ina219.cc
+++ b/src/ina219.cc
@@ -7,17 +7,9 @@
 #include <bitset>
 #include <math.h>
 
-INA219::INA219(float shunt_resistance, float max_expected_amps)
+INA219::INA219(float shunt_resistance, float max_expected_amps, uint8_t address, const char* i2c_bus)
 {
-	init_i2c(__ADDRESS);
-
-	_shunt_ohms = shunt_resistance;
-	_max_expected_amps = max_expected_amps;
-	_min_device_current_lsb = __CALIBRATION_FACTOR / (_shunt_ohms * __MAX_CALIBRATION_VALUE);
-}
-INA219::INA219(float shunt_resistance, float max_expected_amps, uint8_t address)
-{
-	init_i2c(address);
+	init_i2c(address, i2c_bus);
 
 	_shunt_ohms = shunt_resistance;
 	_max_expected_amps = max_expected_amps;
@@ -28,12 +20,10 @@ INA219::~INA219()
 	close(_file_descriptor);
 }
 
-
-
 void
-INA219::init_i2c(uint8_t address)
+INA219::init_i2c(uint8_t address, const char* i2c_bus)
 {
-	char *filename = (char*)"/dev/i2c-1";
+	char *filename = (char*)i2c_bus;
 	if ((_file_descriptor = open(filename, O_RDWR)) < 0)
 	{
 		perror("Failed to open the i2c bus");

--- a/src/ina219.h
+++ b/src/ina219.h
@@ -42,6 +42,8 @@
 #define ADC_64SAMP                          14 // 64 samples at 12-bit, conversion time 34.05ms.
 #define ADC_128SAMP                         15 // 128 samples at 12-bit, conversion time 68.10ms.
 
+#define __I2C_BUS                           "/dev/i2c-1"
+
 #define __ADDRESS                           0x40
 
 #define __REG_CONFIG                        0x00
@@ -106,28 +108,21 @@ class INA219
         /**
          * @brief If the current draw from the system is known, it will
          *        give better resolution in the measurements.
+         *        Use custom I2C address and bus.
          * 
          * @param shunt_resistance Shunt resistance in Ohms.
          * @param max_expected_amps Maximum expected current in Amps.
+         * @param address Custom I2C address. (optional)
+         * @param I2C bus. (optional)
          */
-        INA219(float shunt_resistance, float max_expected_amps);
-        /**
-         * @brief If the current draw from the system is known, it will
-         *        give better resolution in the measurements.
-         *        Use custom I2C address.
-         * 
-         * @param shunt_resistance Shunt resistance in Ohms.
-         * @param max_expected_amps Maximum expected current in Amps.
-         * @param address Custom I2C address.
-         */
-        INA219(float shunt_resistance, float max_expected_amps, uint8_t address); // Custom device address and amps
+        INA219(float shunt_resistance, float max_expected_amps, uint8_t address = __ADDRESS, const char* i2c_bus = __I2C_BUS); // Custom device address and amps
 
         ~INA219();
     
     
     // Private functions
     private:
-        void        init_i2c(uint8_t address);
+        void        init_i2c(uint8_t address, const char* i2c_bus);
         uint16_t    read_register(uint8_t register_value);
         void        write_register(uint8_t register_address, uint16_t register_value);
         float       determine_current_lsb(float max_expected_amps, float max_possible_amps);

--- a/src/ina219.h
+++ b/src/ina219.h
@@ -131,7 +131,7 @@ class INA219
         uint16_t    read_register(uint8_t register_value);
         void        write_register(uint8_t register_address, uint16_t register_value);
         float       determine_current_lsb(float max_expected_amps, float max_possible_amps);
-        void        calibrate(int bus_volts_max, float shunt_volts_max, float max_expected_amps);
+        void        calibrate(float shunt_volts_max, float max_expected_amps);
     
 
     // Private viarables


### PR DESCRIPTION
Added an optional argument in `INA219::init_i2c()` to be able to specify the i2c device file (if not specified the default `/dev/i2c-1` is used, as before).